### PR TITLE
Use '=' assignment for android namespace (Gradle 10 readiness)

### DIFF
--- a/whatisnewdialog-sample/build.gradle
+++ b/whatisnewdialog-sample/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    namespace 'com.nonzeroapps.whatisnewdialog.sample'
+    namespace = 'com.nonzeroapps.whatisnewdialog.sample'
     compileSdk 34
     defaultConfig {
         applicationId "com.nonzeroapps.whatisnewdialog.sample"

--- a/whatisnewdialog/build.gradle
+++ b/whatisnewdialog/build.gradle
@@ -55,7 +55,7 @@ task jacocoTestCoverageVerification(type: JacocoCoverageVerification, dependsOn:
 group = 'com.nonzeroapps.whatisnewdialog'
 
 android {
-    namespace 'com.nonzeroapps.whatisnewdialog'
+    namespace = 'com.nonzeroapps.whatisnewdialog'
     compileSdk 34
     defaultConfig {
         minSdk 21


### PR DESCRIPTION
## Summary

Follow-up cleanup. Converts the `namespace` declarations in both modules to the `propName = value` syntax, silencing the Groovy space-assignment deprecation that Gradle 9.5.1 reports for our build scripts.

After this change **no deprecation warnings originate from our own Gradle files**. The two remaining warnings (`aapt2`, `lint-gradle` multi-string dependency notation) come from inside AGP 8.13.2 itself and can only be cleared by a future stable AGP — the only newer AGP available is `9.3.0-alpha12`, which is not suitable for a published library.

No artifact/behavior change.

## Related issues
no issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)