### PR TITLE
Remove deprecated parcelable calls + unused material dependency (1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] - 2026-06-15
+### Removed
+- **Unused `com.google.android.material` dependency**: the library renders its dialog with the
+  AppCompat `AlertDialog` and never referenced any Material component or theme, so the dependency was
+  dropped. This also avoids forcing a `compileSdk` bump that the Material 1.14.x line would require,
+  and it stops leaking an unused transitive dependency onto consumers (supersedes Dependabot #41).
+
+### Changed
+- **Removed deprecated `Bundle` parcelable calls**: `WhatIsNewDialogFragment` now reads its arguments
+  through `androidx.core.os.BundleCompat`, dropping the manual `SDK_INT` branch and the
+  `@Suppress("DEPRECATION")` on the legacy `getParcelable`/`getParcelableArrayList` overloads.
+- Switched the `android.namespace` declarations to `=` assignment for Gradle 10 readiness.
+
 ## [1.2.1] - 2026-06-15
 ### Fixed
 - **Build restored**: Aligned the Gradle/AGP toolchain so the project builds again. A wrapper-only

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 GROUP=com.nonzeroapps.whatisnewdialog
-VERSION_NAME=1.2.1
-VERSION_CODE=11
+VERSION_NAME=1.2.2
+VERSION_CODE=12
 
 POM_DESCRIPTION=An Android library for displaying a dialog where it presents new features in the app.
 

--- a/whatisnewdialog/build.gradle
+++ b/whatisnewdialog/build.gradle
@@ -60,8 +60,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 34
-        versionCode 11
-        versionName "1.2.1"
+        versionCode 12
+        versionName "1.2.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -102,7 +102,6 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.16.1'
 
     implementation 'androidx.appcompat:appcompat:1.7.1'
-    implementation 'com.google.android.material:material:1.11.0'
     implementation 'com.github.bumptech.glide:glide:5.0.7'
     annotationProcessor 'com.github.bumptech.glide:compiler:5.0.7'
     implementation 'androidx.palette:palette:1.0.0'
@@ -115,7 +114,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.nonzeroapps.whatisnewdialog'
                 artifactId = 'whatisnewdialog'
-                version = '1.2.1'
+                version = '1.2.2'
             }
         }
     }

--- a/whatisnewdialog/src/main/java/com/nonzeroapps/whatisnewdialog/fragment/WhatIsNewDialogFragment.kt
+++ b/whatisnewdialog/src/main/java/com/nonzeroapps/whatisnewdialog/fragment/WhatIsNewDialogFragment.kt
@@ -4,6 +4,7 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.BundleCompat
 import androidx.fragment.app.DialogFragment
 import androidx.viewpager.widget.ViewPager
 import com.nonzeroapps.whatisnewdialog.R
@@ -28,18 +29,12 @@ class WhatIsNewDialogFragment : DialogFragment() {
         val view = requireActivity().layoutInflater.inflate(R.layout.newfeaturedialog, null)
 
         mNewFeatureItemArrayList =
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-                arguments?.getParcelableArrayList(NEW_FEATURE_ITEM_LIST, NewFeatureItem::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                arguments?.getParcelableArrayList(NEW_FEATURE_ITEM_LIST)
+            arguments?.let {
+                BundleCompat.getParcelableArrayList(it, NEW_FEATURE_ITEM_LIST, NewFeatureItem::class.java)
             }
         val dialogSettings =
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-                arguments?.getParcelable(DIALOG_SETTINGS, DialogSettings::class.java)
-            } else {
-                @Suppress("DEPRECATION")
-                arguments?.getParcelable(DIALOG_SETTINGS)
+            arguments?.let {
+                BundleCompat.getParcelable(it, DIALOG_SETTINGS, DialogSettings::class.java)
             }
 
         mImageViewPager = view.findViewById(R.id.viewPager)


### PR DESCRIPTION
## Summary

Cleanup pass triggered by reviewing the open PRs.

### Removed deprecated code
`WhatIsNewDialogFragment` previously branched on `Build.VERSION.SDK_INT` and used `@Suppress("DEPRECATION")` for the legacy single-arg `Bundle.getParcelable`/`getParcelableArrayList` overloads. It now uses `androidx.core.os.BundleCompat`, which handles the SDK split internally and is not deprecated. (`Parcelable` itself is **not** deprecated and stays — it is how the models travel through the fragment arguments.)

### Removed unused dependency (supersedes #41)
Dependabot #41 proposed bumping `com.google.android.material` 1.11.0 → 1.14.0. The library never references any Material component or theme (it renders via the AppCompat `AlertDialog` under a `Theme.AppCompat` theme), and the 1.14.x line drags in `androidx.core:core:1.16.0`, which **requires `compileSdk 35`**. Rather than raise `compileSdk` for an unused library, the dependency is dropped entirely — smaller footprint and no transitive leak onto consumers. **#41 can be closed.**

### Other
- `android.namespace` declarations use `=` assignment (Gradle 10 readiness).
- Version bumped to 1.2.2.

### Verification
`./gradlew clean assembleDebug testDebugUnitTest jacocoTestCoverageVerification ktlintCheck` passes locally.

## Related issues
no issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)