### PR TITLE
Refresh README + POM metadata for the published artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # WhatIsNewDialog
- [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=21) [![](https://jitpack.io/v/nonzeroapps/whatisnewdialog.svg)](https://jitpack.io/#nonzeroapps/whatisnewdialog) [![Build Status](https://github.com/berkayturanci/whatisnewdialog/actions/workflows/build.yml/badge.svg)](https://github.com/berkayturanci/whatisnewdialog/actions)
+ [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![API](https://img.shields.io/badge/API-21%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=21) [![](https://jitpack.io/v/berkayturanci/whatisnewdialog.svg)](https://jitpack.io/#berkayturanci/whatisnewdialog) [![Build Status](https://github.com/berkayturanci/whatisnewdialog/actions/workflows/build.yml/badge.svg)](https://github.com/berkayturanci/whatisnewdialog/actions)
  
-What is new dialog for Android is used for presenting new features in the the app. It can be used in the activity starts, from menu or from a button. It is highly customizable and flexible. It has two options (customizable) where user can either select remind me later or close. Close selection will record that dialog for given version name is seen. So next time it won't be shown to the user. It uses Glide for showing gif and images. 
+What is new dialog for Android is used for presenting new features in the app. It can be used in the activity starts, from menu or from a button. It is highly customizable and flexible. It has two options (customizable) where user can either select remind me later or close. Close selection will record that dialog for given version name is seen. So next time it won't be shown to the user. It uses Glide for showing gif and images. 
 
 ![](preview/usage.gif)
 ![](preview/darkModeExample.png)
 
 ## Installation
 
-### Gradle
-You can download from jitpack.
+The library is published via [JitPack](https://jitpack.io/#berkayturanci/whatisnewdialog).
 
-https://jitpack.io/#nonzeroapps/whatisnewdialog
+**1.** Add the JitPack repository (in `settings.gradle` for newer projects, or the root `build.gradle`):
+
+```gradle
+dependencyResolutionManagement {
+    repositories {
+        maven { url 'https://jitpack.io' }
+    }
+}
+```
+
+**2.** Add the dependency:
+
+```gradle
+dependencies {
+    implementation 'com.github.berkayturanci:whatisnewdialog:1.2.2'
+}
+```
 
 ## Features
 - Add unlimited pages for dialog

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,11 +22,11 @@ VERSION_CODE=12
 
 POM_DESCRIPTION=An Android library for displaying a dialog where it presents new features in the app.
 
-POM_URL=https://github.com/nonzeroapps/whatisnewdialog
-POM_SCM_URL=https://github.com/nonzeroapps/whatisnewdialog
-POM_SCM_CONNECTION=scm:git:git://github.com/nonzeroapps/whatisnewdialog.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:nonzeroapps/whatisnewdialog.git
-POM_ISSUE_URL=https://github.com/nonzeroapps/whatisnewdialog/issues
+POM_URL=https://github.com/berkayturanci/whatisnewdialog
+POM_SCM_URL=https://github.com/berkayturanci/whatisnewdialog
+POM_SCM_CONNECTION=scm:git:git://github.com/berkayturanci/whatisnewdialog.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:berkayturanci/whatisnewdialog.git
+POM_ISSUE_URL=https://github.com/berkayturanci/whatisnewdialog/issues
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
## Summary

Documentation/metadata accuracy pass so everything matches the published 1.2.2 artifact.

- The JitPack badge and links pointed at the upstream `nonzeroapps` fork, but the artifact is actually published from this repo as `com.github.berkayturanci:whatisnewdialog`. Updated badge + links.
- The Installation section only linked to JitPack with no usable snippet. Added the JitPack repository setup and the dependency coordinate at the current version (`1.2.2`).
- Updated `POM_URL` / SCM / issue URLs in `gradle.properties` to the `berkayturanci` repository.
- Fixed a "the the app" typo.

Docs/metadata only — no source or build-logic changes.

## Related issues
no issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)