### PR TITLE
Remove unused jitpack.io repository (fixes flaky plugin resolution)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url = "https://jitpack.io" }
         gradlePluginPortal()
     }
     dependencies {
@@ -18,7 +17,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url = "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
## Summary

Local builds intermittently failed at configuration with `Could not resolve org.jlleitschuh.gradle:ktlint-gradle:14.2.0 ... Could not HEAD 'https://jitpack.io/...' ... Read timed out`.

Root cause: `jitpack.io` was listed in the `buildscript` and `allprojects` repositories (before `gradlePluginPortal()`), so Gradle queried the slow JitPack server first. With the wrapper's `retries=0`, a single timeout was fatal. Nothing in the build actually resolves from JitPack — every plugin and dependency is on `google()` / `mavenCentral()` / `gradlePluginPortal()`.

Removing the unused repository fixes the flaky resolution and noticeably speeds up configuration (local clean build dropped from ~90s to ~18s).

Verified locally: `assembleDebug` (library + sample), 18 unit tests, coverage gate and ktlint all pass; the sample APK builds.

## Related issues
no issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)