### PR TITLE
fix(proguard): drop DexGuard-only rule that breaks R8 release builds (1.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2026-07-03
+### Fixed
+- **Release build broken for R8 consumers**: the bundled consumer ProGuard rules shipped Glide's
+  DexGuard-only `-keepresourcexmlelements manifest/application/meta-data@value=GlideModule` rule.
+  R8 (the default Android shrinker) does not recognize this option and aborts `minifyRelease` with
+  `Unknown option "-keepresourcexmlelements"`, so any consuming app with `minifyEnabled true` failed
+  to build a release AAB/APK. Removed the DexGuard-only rule; the valid Glide keep rules are retained.
+
 ## [1.2.2] - 2026-06-15
 ### Removed
 - **Unused `com.google.android.material` dependency**: the library renders its dialog with the

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
 
 ```gradle
 dependencies {
-    implementation 'com.github.berkayturanci:whatisnewdialog:1.2.2'
+    implementation 'com.github.berkayturanci:whatisnewdialog:1.2.3'
 }
 ```
 

--- a/whatisnewdialog/build.gradle
+++ b/whatisnewdialog/build.gradle
@@ -60,8 +60,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 34
-        versionCode 12
-        versionName "1.2.2"
+        versionCode 13
+        versionName "1.2.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -114,7 +114,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.nonzeroapps.whatisnewdialog'
                 artifactId = 'whatisnewdialog'
-                version = '1.2.2'
+                version = '1.2.3'
             }
         }
     }

--- a/whatisnewdialog/proguard-rules.pro
+++ b/whatisnewdialog/proguard-rules.pro
@@ -32,5 +32,8 @@
   public *;
 }
 
-# for DexGuard only
--keepresourcexmlelements manifest/application/meta-data@value=GlideModule
+# NOTE: Glide's "-keepresourcexmlelements manifest/application/meta-data@value=GlideModule"
+# rule is intentionally omitted. It is a DexGuard-only option; R8 (the default shrinker)
+# rejects it with "Unknown option "-keepresourcexmlelements"", which fails minifyRelease
+# for every consumer that ships these consumer ProGuard rules. Consumers on DexGuard can
+# add it themselves.


### PR DESCRIPTION
## Summary

Fixes a **release-build break for R8 consumers** introduced by the bundled consumer ProGuard rules.

`whatisnewdialog/proguard-rules.pro` (shipped as `consumerProguardFiles`) contained Glide's
**DexGuard-only** rule:

```
# for DexGuard only
-keepresourcexmlelements manifest/application/meta-data@value=GlideModule
```

R8 — the **default** Android shrinker — does not recognize `-keepresourcexmlelements` and aborts:

```
Execution failed for task ':app:minifyReleaseWithR8'.
> com.android.tools.r8.internal.g: Unknown option "-keepresourcexmlelements"
  origin: .../jetified-whatisnewdialog-1.2.2/proguard.txt
```

So any consuming app with `minifyEnabled true` fails to build a release AAB/APK on 1.2.2.
Debug builds are unaffected because they do not run R8.

## Change

- **Remove** the DexGuard-only `-keepresourcexmlelements` line from the consumer ProGuard rules
  (replaced with an explanatory note so it is not re-added). The valid Glide keep rules are retained.
- Bump `versionCode 12 → 13`, `versionName`/publish `1.2.2 → 1.2.3`.
- CHANGELOG + README updated to 1.2.3.

## Verification

- `build` + `pr-lint` required checks.
- Downstream: the consuming app (SmartInventory) bumps to 1.2.3 and its release-AAB / `minifyReleaseWithR8`
  job — which failed on 1.2.2 — is expected to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related issues

no issue — hotfix driven by the downstream consumer (SmartInventory release-AAB R8 failure on 1.2.2).
