### PR TITLE
fix(dialog): follow dark mode via explicit DayNight theme (1.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-07-03
+### Fixed
+- **Dark mode: dialog frame stayed light**: the dialog was built with `AlertDialog.Builder(context)`
+  and no theme, so its title bar, button bar, and window background inherited the consuming app's
+  `alertDialogTheme` and rendered light even while the page content followed dark mode. The builder
+  now uses an explicit DayNight theme (`Theme.WhatIsNewDialog`, parent
+  `Theme.AppCompat.DayNight.Dialog.Alert`), so the whole dialog follows the system/app dark mode.
+  Light mode is unchanged.
+
 ## [1.2.3] - 2026-07-03
 ### Fixed
 - **Release build broken for R8 consumers**: the bundled consumer ProGuard rules shipped Glide's

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencyResolutionManagement {
 
 ```gradle
 dependencies {
-    implementation 'com.github.berkayturanci:whatisnewdialog:1.2.3'
+    implementation 'com.github.berkayturanci:whatisnewdialog:1.2.4'
 }
 ```
 

--- a/whatisnewdialog/build.gradle
+++ b/whatisnewdialog/build.gradle
@@ -60,8 +60,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 34
-        versionCode 13
-        versionName "1.2.3"
+        versionCode 14
+        versionName "1.2.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -114,7 +114,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.nonzeroapps.whatisnewdialog'
                 artifactId = 'whatisnewdialog'
-                version = '1.2.3'
+                version = '1.2.4'
             }
         }
     }

--- a/whatisnewdialog/src/main/java/com/nonzeroapps/whatisnewdialog/fragment/WhatIsNewDialogFragment.kt
+++ b/whatisnewdialog/src/main/java/com/nonzeroapps/whatisnewdialog/fragment/WhatIsNewDialogFragment.kt
@@ -45,7 +45,7 @@ class WhatIsNewDialogFragment : DialogFragment() {
             initPage(dialogSettings)
         }
 
-        val builder = AlertDialog.Builder(context).setView(view)
+        val builder = AlertDialog.Builder(context, R.style.Theme_WhatIsNewDialog).setView(view)
 
         if (dialogSettings != null) {
             if (dialogSettings.isShowTitle) {

--- a/whatisnewdialog/src/main/res/values/styles.xml
+++ b/whatisnewdialog/src/main/res/values/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--
+      DayNight-aware theme for the What's New AlertDialog. Passed explicitly to
+      AlertDialog.Builder(context, R.style.Theme_WhatIsNewDialog) so the dialog frame
+      (title bar, button bar, window background) follows the system/app dark mode instead
+      of inheriting the consumer app's alertDialogTheme, which previously left the title and
+      button panels light while the content followed dark mode. Light mode is unchanged.
+    -->
+    <style name="Theme.WhatIsNewDialog" parent="Theme.AppCompat.DayNight.Dialog.Alert">
+        <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
## Summary

In dark mode the dialog's **title bar, button bar, and window background stayed light** while the
page content followed dark mode — because the dialog was built with `AlertDialog.Builder(context)`
and **no theme**, so its frame inherited the consuming app's `alertDialogTheme`.

## Change

- New `Theme.WhatIsNewDialog` style (parent `Theme.AppCompat.DayNight.Dialog.Alert`), passed
  explicitly to `AlertDialog.Builder(context, R.style.Theme_WhatIsNewDialog)`. The whole dialog now
  follows the system/app dark mode. **Light mode is unchanged.**
- Bump `versionCode 13 → 14`, `versionName`/publish `1.2.3 → 1.2.4`; CHANGELOG + README updated.

## Verification

Built the sample app against this change and installed it on a physical device (SM-G980F, Android 13)
in **system dark mode**: the dialog title bar + "SHOW ME LATER"/"CLOSE" button bar now render dark
(they were light on 1.2.3), consistent with the dark page content. No API changes — drop-in for 1.2.3.

## Related issues

no issue — follow-up polish to 1.2.3, reported from downstream on-device testing.
